### PR TITLE
feat: load GITHUB_USERNAME from GitHub API using GH_TOKEN

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,11 +4,24 @@ const nextConfig = {
 	experimental: {
 		// mdxRs: true,
 	},
+	env: {
+		/** GitHub username loaded in build time. */
+		GITHUB_USERNAME: await fetch('https://api.github.com/user',
+			{
+				headers: {
+					Authorization: `token ${process.env.GH_TOKEN}`,
+				},
+				next: {
+					// No revalidation needed. It is fine to get it on build time and use it forever.
+					tags: ['github', 'github-username'],
+				}
+			}
+		).then(res => res.json()).then(data => data.login),
+	},
 	images: {
-		domains: [
-			"avatars.githubusercontent.com",
-			"github.com",
-			"raw.githubusercontent.com",
+		remotePatterns: [
+			{ protocol: 'https', hostname: '**.githubusercontent.com' },
+			{ protocol: 'https', hostname: '**.github.com' }
 		],
 	},
 };


### PR DESCRIPTION
# What
Load `process.env.GITHUB_USERNAME` on build using `GH_TOKEN` and `https://api.github.com/user`.

# Why
Remove the need to set ENV `GITHUB_USERNAME` manually in Vercel. Thus it shows views and dependabot info properly even if the repo owner didn't configure `GITHUB_USERNAME` at all.