### PR TITLE
Refine Copilot/Codex activity presentation on homepage

### DIFF
--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -87,10 +87,23 @@ export const CopilotActivity = async ({ username }) => {
     }
 
     return (
-        <div>
-            <span className="text-sm flex items-center justify-center gap-1">
-                I&apos;ve been shipping with Copilot <SiGithubcopilot className="w-4 h-4 inline" /> and Codex <img src="/codex-icon.svg" alt="Codex" className="w-4 h-4 inline" /> — that&apos;s {copilotPRCount} merged Copilot PR{copilotPRCount === 1 ? '' : 's'} and {codexPRCount} of my merged PR{codexPRCount === 1 ? '' : 's'} tagged <code>codex</code>.
-            </span>
+        <div className="mt-2">
+            <div className="text-sm text-zinc-400 flex flex-wrap items-center justify-center gap-2">
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700/70 bg-zinc-900/50 px-2.5 py-1">
+                    <SiGithubcopilot className="w-4 h-4 text-zinc-300" />
+                    <span>
+                        Copilot: <strong className="text-zinc-200">{copilotPRCount}</strong> merged PR{copilotPRCount === 1 ? '' : 's'}
+                    </span>
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700/70 bg-zinc-900/50 px-2.5 py-1">
+                    <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-emerald-400/10 ring-1 ring-emerald-300/30">
+                        <img src="/codex-icon.svg" alt="Codex" className="w-3 h-3 text-emerald-300" />
+                    </span>
+                    <span>
+                        Codex: <strong className="text-zinc-200">{codexPRCount}</strong> merged PR{codexPRCount === 1 ? '' : 's'} tagged <code className="text-emerald-300">codex</code>
+                    </span>
+                </span>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
### Motivation
- The Copilot/Codex summary line was compact and prone to awkward wrapping and low contrast on dark backgrounds, so it needed clearer hierarchy and better mobile behavior.
- The Codex icon needed a subtler, more intentional treatment so it reads cleanly against the hero background.

### Description
- Updated `app/components/recent-activity.jsx` to replace the single sentence with two compact rounded “badge” pills for Copilot and Codex to improve wrapping and readability.
- Added stronger visual hierarchy for numeric counts using `strong` and tuned spacing and colors with Tailwind utility classes for better contrast on dark backgrounds.
- Wrapped the Codex SVG in a small accent circular container with subtle background and ring to make the icon more legible and visually consistent.

### Testing
- Ran the production build with `npm run build-only` and the site compiled and generated pages successfully.
- No additional automated tests were present or run beyond the Next.js build validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74b142548324a8405d53e51c83ed)