### PR TITLE
Refine Copilot/Codex activity text and replace Codex image with icon

### DIFF
--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -1,5 +1,6 @@
 import { getRecentUserActivity, getCopilotPRsAccountWide, getCodexLabeledPRsAccountWide } from "../data";
 import { SiGithubcopilot } from 'react-icons/si';
+import { SiOpenai } from 'react-icons/si';
 
 
 export const RecentActivity = async ({ username }) => {
@@ -88,9 +89,17 @@ export const CopilotActivity = async ({ username }) => {
 
     return (
         <div>
-            <span className="text-sm flex items-center justify-center gap-1">
-                I&apos;ve been shipping with Copilot <SiGithubcopilot className="w-4 h-4 inline" /> and Codex <img src="/codex-icon.svg" alt="Codex" className="w-4 h-4 inline" /> — that&apos;s {copilotPRCount} merged Copilot PR{copilotPRCount === 1 ? '' : 's'} and {codexPRCount} of my merged PR{codexPRCount === 1 ? '' : 's'} tagged <code>codex</code>.
-            </span>
+            <p className="text-sm max-w-3xl mx-auto leading-relaxed">
+                I&apos;ve been shipping with
+                <span className="inline-flex items-center gap-1 mx-1">
+                    Copilot <SiGithubcopilot className="w-4 h-4" aria-label="GitHub Copilot icon" />
+                </span>
+                and
+                <span className="inline-flex items-center gap-1 mx-1">
+                    Codex <SiOpenai className="w-4 h-4 text-cyan-300" aria-label="Codex icon" />
+                </span>
+                — that&apos;s {copilotPRCount} merged Copilot PR{copilotPRCount === 1 ? '' : 's'} and {codexPRCount} of my merged PR{codexPRCount === 1 ? '' : 's'} tagged <code>codex</code>.
+            </p>
         </div>
     );
 };


### PR DESCRIPTION
### Motivation
- Improve the final Copilot/Codex sentence which wrapped awkwardly on narrow screens and replace the crude inline image for Codex with a cleaner icon for better visual balance and accessibility.

### Description
- Updated `app/components/recent-activity.jsx` to replace the inline Codex image with the `SiOpenai` icon from `react-icons/si` and import it accordingly.
- Reworked the Copilot/Codex sentence to render as a centered paragraph with `max-w-3xl` and `leading-relaxed` and grouped each label with its icon using `inline-flex` spans to avoid awkward wrapping.
- Added `aria-label` attributes to the icons and adjusted spacing classes to improve readability and accessibility.

### Testing
- Ran `npm run lint` which failed because there is no `lint` script defined in `package.json` in this project environment.
- Ran `npm run build` which failed during `lib/setup.mjs` due to a Node runtime incompatibility with the ESM JSON import assertion syntax used in the project's setup script.
- No automated UI tests were run; changes are limited to `recent-activity.jsx` and should display once the project is built in a compatible runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74b142548324a8405d53e51c83ed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Recent Activity component layout and visual presentation for improved readability.

* **Accessibility Improvements**
  * Enhanced accessibility with added descriptive labels for icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->