### PR TITLE
Polish Copilot/Codex activity line layout

### DIFF
--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -87,9 +87,20 @@ export const CopilotActivity = async ({ username }) => {
     }
 
     return (
-        <div>
-            <span className="text-sm flex items-center justify-center gap-1">
-                I&apos;ve been shipping with Copilot <SiGithubcopilot className="w-4 h-4 inline" /> and Codex <img src="/codex-icon.svg" alt="Codex" className="w-4 h-4 inline" /> — that&apos;s {copilotPRCount} merged Copilot PR{copilotPRCount === 1 ? '' : 's'} and {codexPRCount} of my merged PR{codexPRCount === 1 ? '' : 's'} tagged <code>codex</code>.
+        <div className="text-sm flex flex-col items-center gap-1.5">
+            <span className="flex flex-wrap items-center justify-center gap-2 text-center">
+                <span>I&apos;ve been shipping with</span>
+                <span className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-2 py-0.5">
+                    <SiGithubcopilot className="w-4 h-4" />
+                    Copilot
+                </span>
+                <span className="inline-flex items-center gap-1 rounded-full border border-cyan-400/35 bg-cyan-500/10 px-2 py-0.5 text-cyan-100">
+                    <img src="/codex-icon.svg" alt="Codex" className="w-4 h-4" />
+                    Codex
+                </span>
+            </span>
+            <span className="text-center">
+                That&apos;s {copilotPRCount} merged Copilot PR{copilotPRCount === 1 ? '' : 's'} and {codexPRCount} of my merged PR{codexPRCount === 1 ? '' : 's'} tagged <code>codex</code>.
             </span>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Improve the Copilot/Codex line so it wraps cleanly on small screens and reads more intentionally instead of breaking awkwardly across the sentence.

### Description
- Reworked `CopilotActivity` in `app/components/recent-activity.jsx` into a two-line layout with a column container and centered text. 
- Replaced the plain inline label with pill-style badges for Copilot and Codex, keeping the existing `SiGithubcopilot` icon and the `public/codex-icon.svg` image. 
- Added Tailwind utility classes for rounded badges, subtle borders, background accents, and a cyan accent on the Codex badge to visually group icon+label pairs.

### Testing
- Ran `npm run build-only` and the Next.js production build completed successfully. 
- Static pages were generated without errors during the build run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74b142548324a8405d53e51c83ed)