### PR TITLE
Refine homepage contribution copy to emphasize strong signals

### DIFF
--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -44,7 +44,6 @@ export const RecentActivity = async ({ username }) => {
         return acc;
     }, {});
 
-    // End result: I pushed 2 commits and reviewed 1 PR.
     const activitySummaryString = Object.keys(activitySummary).map((key) => {
         const value = activitySummary[key];
         if (key === 'commits' && value) {
@@ -71,7 +70,7 @@ export const RecentActivity = async ({ username }) => {
     return (
         <div>
             <span className="text-sm">
-                {activitySummaryString && 'From recent public GitHub activity, I ' + activitySummaryString + ' in public repositories.'}
+                {activitySummaryString && 'Recent public output: ' + activitySummaryString + '.'}
             </span>
             {/* {JSON.stringify(recentUserActivity.map(a => a.payload?.review && Object.keys(a.payload?.review).join()), null, 4)} */}
             {/* {JSON.stringify(Object.keys(recentUserActivity[4]).join(), null, 4)} */}
@@ -136,7 +135,7 @@ export const CopilotActivity = async ({ username }) => {
     return (
         <div>
             <p className="text-sm max-w-3xl mx-auto leading-relaxed">
-                I&apos;ve been shipping with {toolSummary} — that&apos;s {contributionSummary}.
+                AI-assisted delivery signals: {contributionSummary} using {toolSummary}.
             </p>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Improve the main landing copy to present personal contributions and AI-assisted contributions as concise, measurable signals rather than descriptive prose.

### Description
- Update two copy strings in `app/components/recent-activity.jsx`: change the personal activity line to `Recent public output: ...` and the AI contributions line to `AI-assisted delivery signals: ... using ...`, with no data- or UI-behavior changes.

### Testing
- Ran `npm run lint` which failed because the project has no `lint` script, and ran `npm run build-only` which completed successfully (production build compiled and static pages generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0083ea248324b4c085dec324acac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined the Recent Activity section messaging to better reflect recent public output, moving away from GitHub-specific activity language.
  * Updated the Copilot Activity component to emphasize AI-assisted delivery signals and accomplishments.
  * Enhanced clarity and consistency of activity descriptions throughout the user interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jirihofman/portfolio/pull/362)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->