### PR TITLE
[codex] Show Claude agent contributions

### DIFF
--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -1,6 +1,14 @@
-import { getRecentUserActivity, getCopilotPRsAccountWide, getCodexCoauthoredCommitsAccountWide, getCodexLabeledPRsAccountWide } from "../data";
+import {
+    getRecentUserActivity,
+    getCopilotPRsAccountWide,
+    getCodexCoauthoredCommitsAccountWide,
+    getCodexLabeledPRsAccountWide,
+    getClaudeCoauthoredCommitsAccountWide,
+    getClaudeLabeledPRsAccountWide,
+} from "../data";
 import { SiGithubcopilot } from 'react-icons/si';
 import { SiOpenai } from 'react-icons/si';
+import { SiClaude } from 'react-icons/si';
 
 function joinWithAnd(items) {
     return items.flatMap((item, index) => index === 0 ? [item] : [' and ', item]);
@@ -81,61 +89,53 @@ export const RecentActivity = async ({ username }) => {
 };
 
 export const CopilotActivity = async ({ username }) => {
-    const [copilotPRCount, codexCoauthoredCommitCount, codexLabeledPRCount] = await Promise.all([
+    const [copilotPRCount, codexCoauthoredCommitCount, codexLabeledPRCount, claudeCoauthoredCommitCount, claudeLabeledPRCount] = await Promise.all([
         getCopilotPRsAccountWide(username),
         getCodexCoauthoredCommitsAccountWide(username),
         getCodexLabeledPRsAccountWide(username),
+        getClaudeCoauthoredCommitsAccountWide(username),
+        getClaudeLabeledPRsAccountWide(username),
     ]);
 
     const codexCount = codexCoauthoredCommitCount + codexLabeledPRCount;
+    const claudeCount = claudeCoauthoredCommitCount + claudeLabeledPRCount;
 
-    if (copilotPRCount === 0 && codexCount === 0) {
+    if (copilotPRCount === 0 && codexCount === 0 && claudeCount === 0) {
         return null;
     }
 
-    const contributionParts = [];
+    const agentParts = [];
 
     if (copilotPRCount > 0) {
-        contributionParts.push(
-            <span key="copilot">
-                {copilotPRCount} merged Copilot PR{copilotPRCount === 1 ? '' : 's'}
-            </span>
-        );
-    }
-
-    if (codexCount > 0) {
-        contributionParts.push(
-            <span key="codex">
-                {codexCount} Codex contribution{codexCount === 1 ? '' : 's'}
-            </span>
-        );
-    }
-
-    const toolBadges = [];
-
-    if (copilotPRCount > 0) {
-        toolBadges.push(
+        agentParts.push(
             <span key="copilot" className="inline-flex items-center gap-1 mx-1">
-                Copilot <SiGithubcopilot className="w-4 h-4 text-[#8534F3]" aria-label="GitHub Copilot icon" />
+                Copilot <SiGithubcopilot className="w-4 h-4 text-[#8534F3]" aria-label="GitHub Copilot icon" /> ({copilotPRCount} merged PR{copilotPRCount === 1 ? '' : 's'})
             </span>
         );
     }
 
     if (codexCount > 0) {
-        toolBadges.push(
+        agentParts.push(
             <span key="codex" className="inline-flex items-center gap-1 mx-1">
-                Codex <SiOpenai className="w-4 h-4 text-cyan-300" aria-label="Codex icon" />
+                Codex <SiOpenai className="w-4 h-4 text-cyan-300" aria-label="Codex icon" /> ({codexCount} contribution{codexCount === 1 ? '' : 's'})
             </span>
         );
     }
 
-    const contributionSummary = joinWithAnd(contributionParts);
-    const toolSummary = joinWithAnd(toolBadges);
+    if (claudeCount > 0) {
+        agentParts.push(
+            <span key="claude" className="inline-flex items-center gap-1 mx-1">
+                Claude <SiClaude className="w-4 h-4 text-orange-300" aria-label="Claude icon" /> ({claudeCount} contribution{claudeCount === 1 ? '' : 's'})
+            </span>
+        );
+    }
+
+    const agentSummary = joinWithAnd(agentParts);
 
     return (
         <div>
             <p className="text-sm max-w-3xl mx-auto leading-relaxed">
-                AI-assisted delivery signals: {contributionSummary} using {toolSummary}.
+                AI-assisted delivery signals: {agentSummary}.
             </p>
         </div>
     );

--- a/app/data.js
+++ b/app/data.js
@@ -12,6 +12,7 @@ const GITHUB_API_URL = 'https://api.github.com';
 const GITHUB_GRAPHQL_URL = `${GITHUB_API_URL}/graphql`;
 const COPILOT_GRAPHQL_BATCH_SIZE = 20;
 const CODEX_GRAPHQL_BATCH_SIZE = 10;
+const CLAUDE_GRAPHQL_BATCH_SIZE = 10;
 const PORTFOLIO_OWNER_USERNAME = process.env.GITHUB_USERNAME || data.githubUsername;
 
 function cloneFallbackValue(fallback) {
@@ -201,12 +202,28 @@ function buildCodexCoauthoredCommitSearchQuery(username) {
     return `author:${username} "Co-authored-by: Codex"`;
 }
 
+function buildClaudeCoauthoredCommitSearchQuery(username) {
+    if (typeof username !== 'string' || !/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username)) {
+        return null;
+    }
+
+    return `author:${username} "Co-authored-by: Claude"`;
+}
+
 function buildCodexLabeledAccountSearchQuery(username) {
     if (typeof username !== 'string' || !/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username)) {
         return null;
     }
 
     return `is:pr is:merged author:${username} label:codex`;
+}
+
+function buildClaudeLabeledAccountSearchQuery(username) {
+    if (typeof username !== 'string' || !/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username)) {
+        return null;
+    }
+
+    return `is:pr is:merged author:${username} label:claude`;
 }
 
 function buildCodexLabeledPRRepoSearchQuery(username, reponame) {
@@ -219,6 +236,18 @@ function buildCodexLabeledPRRepoSearchQuery(username, reponame) {
     }
 
     return `is:pr is:merged author:${username} label:codex repo:${username}/${reponame}`;
+}
+
+function buildClaudeLabeledPRRepoSearchQuery(username, reponame) {
+    if (typeof username !== 'string' || typeof reponame !== 'string') {
+        return null;
+    }
+
+    if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username) || !/^[a-zA-Z0-9._-]{1,100}$/.test(reponame)) {
+        return null;
+    }
+
+    return `is:pr is:merged author:${username} label:claude repo:${username}/${reponame}`;
 }
 
 // TODO: Implement option to switch between info for authenticated user and other users.
@@ -648,6 +677,49 @@ async function getCodexCounts(repositories) {
     return counts.reduce((acc, chunkResult) => Object.assign(acc, chunkResult), {});
 }
 
+async function fetchClaudeCountChunk(repositories) {
+    const searchableRepositories = repositories.filter((project) =>
+        buildClaudeLabeledPRRepoSearchQuery(project.owner?.login, project.name)
+    );
+
+    if (!searchableRepositories.length) {
+        return {};
+    }
+
+    // GitHub GraphQL cannot search commits, so repository card counts are based on labeled PRs.
+    const variableDefinitions = searchableRepositories.map((_, index) => `$pr${index}: String!`).join(', ');
+    const searches = searchableRepositories.map((_, index) => `
+        pr${index}: search(type: ISSUE, query: $pr${index}, first: 1) {
+            issueCount
+        }
+    `).join('\n');
+    const variables = Object.fromEntries(
+        searchableRepositories.map((project, index) => [
+            `pr${index}`, buildClaudeLabeledPRRepoSearchQuery(project.owner.login, project.name),
+        ])
+    );
+
+    const response = await fetchGitHubGraphQL(`
+        query BatchClaudeCounts(${variableDefinitions}) {
+            ${searches}
+        }
+    `, variables, {
+        context: `batched Claude counts for ${searchableRepositories.length} repositories`,
+        fallback: {},
+        next: { revalidate: HOURS_12 },
+    });
+
+    return searchableRepositories.reduce((acc, project, index) => {
+        acc[getRepositoryKey(project)] = response[`pr${index}`]?.issueCount ?? 0;
+        return acc;
+    }, {});
+}
+
+async function getClaudeCounts(repositories) {
+    const counts = await Promise.all(chunkItems(repositories, CLAUDE_GRAPHQL_BATCH_SIZE).map(fetchClaudeCountChunk));
+    return counts.reduce((acc, chunkResult) => Object.assign(acc, chunkResult), {});
+}
+
 async function getRepositoryVercelDetails(username, reponame, nextjsLatestRelease) {
     try {
         const [packageJson, routerInfo, repositoryFrameworks] = await Promise.all([
@@ -672,9 +744,10 @@ async function getRepositoryVercelDetails(username, reponame, nextjsLatestReleas
 async function enrichProjectsForCards(projects) {
     const ownerProjects = projects.filter((project) => isOwnedRepository(project, PORTFOLIO_OWNER_USERNAME));
     const hasVercelProjects = projects.some((project) => project.vercel);
-    const [copilotPRCounts, codexCounts, nextjsLatestRelease] = await Promise.all([
+    const [copilotPRCounts, codexCounts, claudeCounts, nextjsLatestRelease] = await Promise.all([
         getCopilotPRCounts(ownerProjects),
         getCodexCounts(ownerProjects),
+        getClaudeCounts(ownerProjects),
         hasVercelProjects ? getNextjsLatestRelease() : Promise.resolve({}),
     ]);
 
@@ -695,6 +768,7 @@ async function enrichProjectsForCards(projects) {
                 openAlertsBySeverity,
                 copilotPRCount: isOwnerRepo ? (copilotPRCounts[getRepositoryKey(project)] ?? null) : null,
                 codexCount: isOwnerRepo ? (codexCounts[getRepositoryKey(project)] ?? null) : null,
+                claudeCount: isOwnerRepo ? (claudeCounts[getRepositoryKey(project)] ?? null) : null,
             },
             vercel: project.vercel ? {
                 ...project.vercel,
@@ -870,6 +944,39 @@ export const getCodexCoauthoredCommitsAccountWide = unstable_cache(async (userna
 }, (username) => ['getCodexCoauthoredCommitsAccountWide', username], { revalidate: HOURS_12 });
 
 /**
+ * Get the total number of commits authored by the user that include the "Co-authored-by: Claude" trailer.
+ * Uses GitHub commit search account-wide (not repository-specific).
+ * @param {string} username GitHub username
+ * @returns {number} Number of commits authored by the user that were co-authored by Claude
+ */
+export const getClaudeCoauthoredCommitsAccountWide = unstable_cache(async (username) => {
+    console.log(`Fetching account-wide Claude co-authored commits for ${username}`);
+    console.time('getClaudeCoauthoredCommitsAccountWide');
+
+    try {
+        const query = buildClaudeCoauthoredCommitSearchQuery(username);
+
+        if (!query) {
+            return 0;
+        }
+
+        const response = await fetchGitHubJson(`${GITHUB_API_URL}/search/commits?q=${encodeURIComponent(query)}&per_page=1`, {
+            context: `account-wide Claude co-authored commits for ${username}`,
+            fallback: { total_count: 0 },
+            headers: { Accept: 'application/vnd.github.cloak-preview+json' },
+            next: { revalidate: HOURS_12 },
+        });
+
+        return typeof response?.total_count === 'number' ? response.total_count : 0;
+    } catch (error) {
+        console.error(`Error getting account-wide Claude co-authored commits for ${username}:`, error);
+        return 0;
+    } finally {
+        console.timeEnd('getClaudeCoauthoredCommitsAccountWide');
+    }
+}, (username) => ['getClaudeCoauthoredCommitsAccountWide', username], { revalidate: HOURS_12 });
+
+/**
  * Get the total number of merged pull requests authored by the user that have the "codex" label.
  * Uses GitHub GraphQL API to search account-wide (not repository-specific).
  * @param {string} username GitHub username
@@ -905,6 +1012,43 @@ export const getCodexLabeledPRsAccountWide = unstable_cache(async (username) => 
         console.timeEnd('getCodexLabeledPRsAccountWide');
     }
 }, (username) => ['getCodexLabeledPRsAccountWide', username], { revalidate: HOURS_12 });
+
+/**
+ * Get the total number of merged pull requests authored by the user that have the "claude" label.
+ * Uses GitHub GraphQL API to search account-wide (not repository-specific).
+ * @param {string} username GitHub username
+ * @returns {number} Number of merged, claude-labeled PRs authored by the user
+ */
+export const getClaudeLabeledPRsAccountWide = unstable_cache(async (username) => {
+    console.log(`Fetching account-wide claude-labeled PRs for ${username}`);
+    console.time('getClaudeLabeledPRsAccountWide');
+
+    try {
+        const query = buildClaudeLabeledAccountSearchQuery(username);
+
+        if (!query) {
+            return 0;
+        }
+
+        const response = await fetchGitHubGraphQL(`
+            query ClaudeLabeledMergedPRsAccountWide($q: String!) {
+                search(type: ISSUE, query: $q, first: 1) {
+                    issueCount
+                }
+            }
+        `, { q: query }, {
+            context: `account-wide claude-labeled PRs for ${username}`,
+            fallback: { search: { issueCount: 0 } },
+        });
+
+        return response.search?.issueCount || 0;
+    } catch (error) {
+        console.error(`Error getting account-wide claude-labeled PRs for ${username}:`, error);
+        return 0;
+    } finally {
+        console.timeEnd('getClaudeLabeledPRsAccountWide');
+    }
+}, (username) => ['getClaudeLabeledPRsAccountWide', username], { revalidate: HOURS_12 });
 
 /**
  * Detects frameworks from package.json dependencies and devDependencies

--- a/app/projects/article.jsx
+++ b/app/projects/article.jsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { FaGithub } from "react-icons/fa";
 import { GoDependabot, GoEye, GoEyeClosed, GoStar } from 'react-icons/go';
-import { SiGithubcopilot, SiOpenai } from 'react-icons/si';
+import { SiClaude, SiGithubcopilot, SiOpenai } from 'react-icons/si';
 import { VercelInfo } from "../components/vercel-info";
 
 export const Article = ({ project }) => {
@@ -12,12 +12,14 @@ export const Article = ({ project }) => {
     const alertsData = ownerMetrics?.openAlertsBySeverity;
     const copilotPRCount = ownerMetrics?.copilotPRCount;
     const codexCount = ownerMetrics?.codexCount;
+    const claudeCount = ownerMetrics?.claudeCount;
 
     /** Repository visitors info. */
     let views = <span title="Can't get traffic data for someone else's repo." className="flex items-center gap-1"><GoEyeClosed className="w-4 h-4" /></span>;
     let alerts = <span title="Can't get alerts data for someone else's repo."><GoDependabot className="w-4 h-4" /></span>;
     let copilotPRs = <span title="Can't get Copilot data for someone else's repo."><SiGithubcopilot className="w-3.5 h-3.5 text-[#8534F3]" /></span>;
     let codexContributions = <span title="Can't get Codex data for someone else's repo."><SiOpenai className="w-3.5 h-3.5 text-cyan-300" /></span>;
+    let claudeContributions = <span title="Can't get Claude data for someone else's repo."><SiClaude className="w-3.5 h-3.5 text-orange-300" /></span>;
     if (viewsData) {
         const { todayUniques = 0, sumUniques = 0 } = viewsData;
         views = <span title="Unique repository visitors: Last 14 days / Yesterday (GitHub API has 24-hour delay)." className="flex items-center gap-1">
@@ -63,6 +65,19 @@ export const Article = ({ project }) => {
         </Link>;
     }
 
+    if (claudeCount !== null && claudeCount !== undefined) {
+        claudeContributions = <Link
+            href={`https://github.com/${project.owner.login}/${project.name}/pulls?q=is%3Apr+is%3Amerged+label%3Aclaude`}
+            title={`Claude contributions: ${claudeCount} (labeled PRs)`}
+            className="flex items-center gap-1 hover:text-blue-500"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            <SiClaude className="w-3.5 h-3.5 text-orange-300" />{" "}
+            {Intl.NumberFormat("en-US", { notation: "compact" }).format(claudeCount)}
+        </Link>;
+    }
+
     return (
         <article className="p-4 md:p-8">
             <div className="flex justify-between gap-2 items-center">
@@ -103,6 +118,8 @@ export const Article = ({ project }) => {
                     {copilotPRs}
                     {" "}
                     {codexContributions}
+                    {" "}
+                    {claudeContributions}
                 </span>
             </div>
             <div className="flex justify-between gap-2 items-center float-right mt-2 border-t-2 border-gray-700 border-opacity-50">


### PR DESCRIPTION
## Summary
- add Claude contribution counting from co-authored commit trailers and claude-labeled merged PRs
- render Claude in the homepage AI tooling summary with its icon
- add Claude contribution badges to project cards for owner repositories

## Validation
- npm run build with Node v20.18.3
- checked GitHub commit search for author:jirihofman "Co-authored-by: Claude" returns results

## Notes
- Repository card Claude counts follow the existing GraphQL batched PR-label approach because GitHub GraphQL does not support commit search. Account-wide homepage counts include commit trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude activity tracking to project and account summaries.
  * Project cards now include a “Claude contributions” metric with quick links to Claude-labeled merged pull requests.
  * Recent activity “delivery signals” now displays Claude alongside other agents, including icon-based counts and updated wording.
  * Added account-wide support for counting Claude-labeled PRs and co-authored commits to power the new metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->