### PR TITLE
Use official OpenAI Codex icon

### DIFF
--- a/app/components/codex-icon.jsx
+++ b/app/components/codex-icon.jsx
@@ -1,0 +1,9 @@
+export function CodexIcon({ className = "w-4 h-4", alt = "OpenAI Codex icon" }) {
+    return (
+        <img
+            src="/codex-icon.svg"
+            alt={alt}
+            className={className}
+        />
+    );
+}

--- a/app/components/codex-icon.jsx
+++ b/app/components/codex-icon.jsx
@@ -1,9 +1,13 @@
-export function CodexIcon({ className = "w-4 h-4", alt = "OpenAI Codex icon" }) {
+export function CodexIcon({ className = "w-4 h-4", label = "OpenAI Codex icon" }) {
     return (
-        <img
-            src="/codex-icon.svg"
-            alt={alt}
-            className={className}
+        <span
+            role="img"
+            aria-label={label}
+            className={`inline-block shrink-0 bg-current align-[-0.125em] ${className}`}
+            style={{
+                WebkitMask: 'url(/codex-icon.svg) center / contain no-repeat',
+                mask: 'url(/codex-icon.svg) center / contain no-repeat',
+            }}
         />
     );
 }

--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -8,7 +8,7 @@ import {
 } from "../data";
 import { SiGithubcopilot } from 'react-icons/si';
 import { SiClaude } from 'react-icons/si';
-import { FaRobot } from 'react-icons/fa';
+import { CodexIcon } from './codex-icon';
 
 function joinWithAnd(items) {
     return items.flatMap((item, index) => index === 0 ? [item] : [' and ', item]);
@@ -117,7 +117,7 @@ export const CopilotActivity = async ({ username }) => {
     if (codexCount > 0) {
         agentParts.push(
             <span key="codex" className="inline-flex items-center gap-1 mx-1">
-                Codex <FaRobot className="w-4 h-4 text-cyan-300" aria-label="Codex icon" /> ({codexCount} contribution{codexCount === 1 ? '' : 's'})
+                Codex <CodexIcon className="w-4 h-4 text-cyan-300" /> ({codexCount} contribution{codexCount === 1 ? '' : 's'})
             </span>
         );
     }

--- a/app/projects/article.jsx
+++ b/app/projects/article.jsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
-import { FaGithub, FaRobot } from "react-icons/fa";
+import { FaGithub } from "react-icons/fa";
 import { GoDependabot, GoEye, GoEyeClosed, GoStar } from 'react-icons/go';
 import { SiClaude, SiGithubcopilot } from 'react-icons/si';
 import { VercelInfo } from "../components/vercel-info";
+import { CodexIcon } from "../components/codex-icon";
 
 export const Article = ({ project }) => {
 
@@ -18,7 +19,7 @@ export const Article = ({ project }) => {
     let views = <span title="Can't get traffic data for someone else's repo." className="flex items-center gap-1"><GoEyeClosed className="w-4 h-4" /></span>;
     let alerts = <span title="Can't get alerts data for someone else's repo."><GoDependabot className="w-4 h-4" /></span>;
     let copilotPRs = <span title="Can't get Copilot data for someone else's repo."><SiGithubcopilot className="w-3.5 h-3.5 text-[#8534F3]" /></span>;
-    let codexContributions = <span title="Can't get Codex data for someone else's repo."><FaRobot className="w-3.5 h-3.5 text-cyan-300" /></span>;
+    let codexContributions = <span title="Can't get Codex data for someone else's repo."><CodexIcon className="w-3.5 h-3.5 text-cyan-300" /></span>;
     let claudeContributions = <span title="Can't get Claude data for someone else's repo."><SiClaude className="w-3.5 h-3.5 text-orange-300" /></span>;
     if (viewsData) {
         const { todayUniques = 0, sumUniques = 0 } = viewsData;
@@ -60,7 +61,7 @@ export const Article = ({ project }) => {
             target="_blank"
             rel="noopener noreferrer"
         >
-            <FaRobot className="w-3.5 h-3.5 text-cyan-300" />{" "}
+            <CodexIcon className="w-3.5 h-3.5 text-cyan-300" />{" "}
             {Intl.NumberFormat("en-US", { notation: "compact" }).format(codexCount)}
         </Link>;
     }


### PR DESCRIPTION
### Motivation
- Replace the current robot icon with the official OpenAI Codex icon on both the homepage and project cards to use the proper brand asset and provide a single reusable icon component.

### Description
- Add `app/components/codex-icon.jsx`, a small reusable component that renders the existing `/codex-icon.svg` asset with configurable `className` and `alt`.
- Replace usages of the robot glyph with `CodexIcon` in `app/components/recent-activity.jsx` and `app/projects/article.jsx`, and remove the `FaRobot` dependency where it was replaced.
- Keep existing sizing and CSS class usage so visual layout and styles remain unchanged.

### Testing
- Ran `npm run build-only`, which completed successfully and produced the static/app routes without errors.
- Attempted the screenshot/dev smoke script that uses `playwright`, but it could not run because the environment does not have the `playwright` module installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d888267c08324bcd1b037432bb4a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Codex icon component for consistent use across the app.
  * Improved AI-assisted activity labeling for more natural, human-readable phrasing.

* **UI Updates**
  * Replaced the generic robot icon with the new Codex icon in both activity and article contribution views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->