### PR TITLE
Show total published GitHub releases

### DIFF
--- a/app/components/recent-activity.jsx
+++ b/app/components/recent-activity.jsx
@@ -1,5 +1,6 @@
 import {
     getRecentUserActivity,
+    getPublishedReleaseSummary,
     getCopilotPRsAccountWide,
     getCodexCoauthoredCommitsAccountWide,
     getCodexLabeledPRsAccountWide,
@@ -17,7 +18,10 @@ function joinWithAnd(items) {
 
 export const RecentActivity = async ({ username }) => {
 
-    const recentUserActivity = await getRecentUserActivity(username);
+    const [recentUserActivity, publishedReleaseSummary] = await Promise.all([
+        getRecentUserActivity(username),
+        getPublishedReleaseSummary(username),
+    ]);
     const activitySummary = recentUserActivity.reduce((acc, activity) => {
 
         if (activity.type === 'PushEvent') {
@@ -80,6 +84,9 @@ export const RecentActivity = async ({ username }) => {
             <span className="text-sm">
                 {activitySummaryString && 'Recent public output: ' + activitySummaryString + '.'}
             </span>
+            <div className="text-sm">
+                Published {publishedReleaseSummary.releaseCount} GitHub release{publishedReleaseSummary.releaseCount === 1 ? '' : 's'} across {publishedReleaseSummary.repositoryCount} public repositor{publishedReleaseSummary.repositoryCount === 1 ? 'y' : 'ies'}.
+            </div>
             {/* {JSON.stringify(recentUserActivity.map(a => a.payload?.review && Object.keys(a.payload?.review).join()), null, 4)} */}
             {/* {JSON.stringify(Object.keys(recentUserActivity[4]).join(), null, 4)} */}
             {/* {JSON.stringify(recentUserActivity.filter(a => a.type === 'PullRequestEvent')[2], null, 4)} */}

--- a/app/data.js
+++ b/app/data.js
@@ -6,6 +6,7 @@ import data from '../data.json';
 const revalidate = 60;
 const MINUTES_5 = 60 * 5;
 const HOURS_1 = 60 * 60;
+const HOURS_6 = 60 * 60 * 6;
 const HOURS_12 = 60 * 60 * 12;
 const HOURS_24 = 60 * 60 * 24;
 const GITHUB_API_URL = 'https://api.github.com';
@@ -532,6 +533,52 @@ export const getRecentUserActivity = unstable_cache(async (username) => {
     console.timeEnd('getRecentUserActivity');
     return response;
 }, (username) => ['getRecentUserActivity', username], { revalidate: MINUTES_5 });
+
+export const getPublishedReleaseSummary = unstable_cache(async (username) => {
+    let after = null;
+    let releaseCount = 0;
+    let repositoryCount = 0;
+
+    do {
+        const response = await fetchGitHubGraphQL(`
+            query GetPublishedReleaseSummary($username: String!, $after: String) {
+                user(login: $username) {
+                    repositories(
+                        first: 100
+                        after: $after
+                        ownerAffiliations: OWNER
+                        privacy: PUBLIC
+                    ) {
+                        pageInfo {
+                            endCursor
+                            hasNextPage
+                        }
+                        nodes {
+                            releases(first: 1) {
+                                totalCount
+                            }
+                        }
+                    }
+                }
+            }
+        `, { username, after }, {
+            context: `published release summary for ${username}`,
+            fallback: { user: { repositories: { nodes: [], pageInfo: { endCursor: null, hasNextPage: false } } } },
+        });
+
+        const repositories = response.user?.repositories;
+
+        for (const repository of repositories?.nodes ?? []) {
+            const count = repository?.releases?.totalCount ?? 0;
+            releaseCount += count;
+            repositoryCount += count > 0 ? 1 : 0;
+        }
+
+        after = repositories?.pageInfo?.hasNextPage ? repositories.pageInfo.endCursor : null;
+    } while (after);
+
+    return { releaseCount, repositoryCount };
+}, (username) => ['getPublishedReleaseSummary', username], { revalidate: HOURS_6 });
 
 export const getTrafficPageViews = unstable_cache(async (username, reponame) => {
     const response = await fetchGitHubResponse(`${GITHUB_API_URL}/repos/${username}/${reponame}/traffic/views`, {


### PR DESCRIPTION
## What changed

- add an account-wide total of published GitHub releases to the homepage activity summary
- count releases across all public repositories owned by the displayed profile
- paginate repositories and cache the aggregate for six hours

## Why

The portfolio shows recent output and AI-assisted contribution totals, but it did not expose lifetime release output. This adds that durable delivery signal while describing its scope precisely.

## User impact

Visitors now see the total number of GitHub releases and the number of public repositories containing them.

## Validation

- `git diff --check`
- live GitHub GraphQL query validation
- `npm run build`
- rendered homepage verification against the local development server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent activity now displays the total number of published GitHub releases and the public repositories containing them.
  * Release counts are presented with appropriate singular and plural wording.
  * Release summary information is refreshed periodically for faster, more consistent viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->