### PR TITLE
Add optional OpenRouter AI usage statistics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 GH_TOKEN=
 VC_TOKEN=
 IS_TEMPLATE=true
+
+# Optional: server-only OpenRouter management key enables /ai-usage
+OPENROUTER_MANAGEMENT_KEY=

--- a/README.md
+++ b/README.md
@@ -119,3 +119,21 @@ The AI agent will:
 **Manual Removal:**
 
 If you prefer to remove template functionality manually, follow the detailed instructions in `.github/prompts/remove-template.md`.
+
+## AI usage (optional)
+
+Set `OPENROUTER_MANAGEMENT_KEY` in `.env.local` and restart the dev server to enable `/ai-usage` and its navigation links on the main portfolio. Without a key, the page returns 404 and the links are hidden. Other GitHub profiles never display the owner's AI usage links.
+
+Use an OpenRouter **management key**, not a standard inference key. The [activity API](https://openrouter.ai/docs/api/api-reference/analytics/get-user-activity) requires it and returns the last 30 completed UTC days. The key is used server-side for the activity endpoint and an aggregate analytics query for cached input tokens. Never use a `NEXT_PUBLIC_` variable or commit a key.
+
+The public page shows model names, daily request counts, input/output/reasoning token counts, model shares, and active days. It excludes prompts, conversations, account/member details, endpoint and key identifiers, and all spending data. Reasoning tokens are already part of output tokens. Cached input tokens are shown when the analytics API provides a complete result; unavailable cache data is omitted, not reported as zero. Cached tokens are already included in input tokens. Only allowlisted aggregates are cached for six hours, with revalidation on a subsequent request; an already open page does not poll. The timestamp shows when the displayed data was fetched, without a cache-duration label. Activity API failures show a neutral unavailable state; analytics failures omit the cached-token row while keeping the rest of the page available. No additional key or browser setup is needed.
+
+### Vercel configuration
+
+Add `OPENROUTER_MANAGEMENT_KEY` in the portfolio project's **Settings → Environment Variables** before deploying this feature. Use a Sensitive variable for Production and Preview. Preview scope enables live statistics in PR deployments; omit that scope if previews should not access the account. Keep the value server-only and use the same management key as local development. Development can continue using the ignored `.env.local` file.
+
+Environment changes apply to new deployments. Redeploy the relevant environment after adding, replacing, or removing the key so navigation and the page use the new configuration. Removing the variable disables the feature; it does not revoke the key at OpenRouter.
+
+### Verification
+
+Run `node --test lib/ai-usage.test.mjs` for date boundaries, aggregation, privacy filtering, and cached-token parsing (including zero, missing, invalid, and partial results). Run `npm run build-only` to validate the Next.js production build without running the template setup script. With the dev server running, open `/ai-usage` and check the daily totals and token breakdown; without a key, expect a 404.

--- a/app/ai-usage/data.js
+++ b/app/ai-usage/data.js
@@ -1,0 +1,68 @@
+import "server-only";
+import { unstable_cache } from "next/cache";
+import { aggregateActivity, parseCachedTokens } from "../../lib/ai-usage.mjs";
+
+async function getCachedTokens(now) {
+  const end = new Date(now);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 30);
+  try {
+    const response = await fetch(
+      "https://openrouter.ai/api/v1/analytics/query",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.OPENROUTER_MANAGEMENT_KEY.trim()}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          metrics: ["cached_tokens"],
+          time_range: { start: start.toISOString(), end: end.toISOString() },
+        }),
+        cache: "no-store",
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!response.ok) return null;
+    return parseCachedTokens(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+export function isAiUsageEnabled() {
+  return Boolean(process.env.OPENROUTER_MANAGEMENT_KEY?.trim());
+}
+
+// Cache only the public aggregates, never the key or raw upstream response.
+const loadUsage = unstable_cache(
+  async () => {
+    const now = new Date();
+    const response = await fetch("https://openrouter.ai/api/v1/activity", {
+      headers: {
+        Authorization: `Bearer ${process.env.OPENROUTER_MANAGEMENT_KEY.trim()}`,
+      },
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error("AI usage unavailable");
+    const payload = await response.json();
+    if (!Array.isArray(payload.data)) throw new Error("AI usage unavailable");
+    return {
+      ...aggregateActivity(payload.data, now),
+      cachedTokens: await getCachedTokens(now),
+      updatedAt: new Date().toISOString(),
+    };
+  },
+  ["openrouter-public-usage-v2"],
+  { revalidate: 6 * 60 * 60 },
+);
+
+export async function getAiUsage() {
+  try {
+    return await loadUsage();
+  } catch {
+    return null;
+  }
+}

--- a/app/ai-usage/page.jsx
+++ b/app/ai-usage/page.jsx
@@ -1,0 +1,250 @@
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { Navigation } from "../components/nav";
+import { getAiUsage, isAiUsageEnabled } from "./data";
+
+export const metadata = {
+  title: "AI usage",
+  description:
+    "Aggregate OpenRouter activity and model preferences. No prompts or personal information.",
+};
+export const dynamic = "force-dynamic";
+const number = (value) => new Intl.NumberFormat("en-US").format(value);
+const dateLabel = (value) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(value));
+const panel = "rounded-2xl border border-zinc-800 bg-zinc-900/40 p-6";
+
+async function Usage() {
+  const usage = await getAiUsage();
+  if (!usage)
+    return (
+      <section className={panel} role="status">
+        <h2 className="text-xl text-zinc-100">
+          Usage is temporarily unavailable
+        </h2>
+        <p className="mt-3 text-zinc-400">
+          OpenRouter statistics could not be loaded. Please try again shortly.
+        </p>
+        <a
+          href="/ai-usage"
+          className="mt-5 inline-block text-emerald-300 underline"
+        >
+          Try again
+        </a>
+      </section>
+    );
+  const maxRequests = Math.max(1, ...usage.days.map((day) => day.requests));
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-zinc-400">
+        <p>
+          {dateLabel(usage.days[0].date)} – {dateLabel(usage.days.at(-1).date)}{" "}
+          · Last 30 completed UTC days
+        </p>
+        <p>
+          Updated{" "}
+          {new Intl.DateTimeFormat("en-GB", {
+            hour: "2-digit",
+            minute: "2-digit",
+            timeZone: "UTC",
+          }).format(new Date(usage.updatedAt))}{" "}
+          UTC
+        </p>
+      </div>
+      <section
+        aria-label="Usage totals"
+        className="grid grid-cols-2 gap-4 lg:grid-cols-4"
+      >
+        {[
+          ["Requests", usage.requests, "Across all models"],
+          ["Tokens", usage.tokens, "Input + output"],
+          ["Models explored", usage.models.length, "Distinct models used"],
+          ["Active days", usage.activeDays, "Out of 30 days"],
+        ].map(([label, value, detail]) => (
+          <div className={panel} key={label}>
+            <p className="text-sm text-zinc-400">{label}</p>
+            <p className="my-3 break-words text-3xl font-display text-zinc-100 sm:text-4xl">
+              {number(value)}
+            </p>
+            <p className="text-xs text-zinc-500">{detail}</p>
+          </div>
+        ))}
+      </section>
+      {usage.requests === 0 && (
+        <section className={panel}>
+          <h2 className="text-xl text-zinc-100">No activity in this period</h2>
+          <p className="mt-2 text-zinc-400">
+            New OpenRouter usage will appear here after the UTC day is complete.
+          </p>
+        </section>
+      )}
+      <section className={panel} aria-labelledby="daily-heading">
+        <div className="flex flex-wrap justify-between gap-2">
+          <h2 id="daily-heading" className="text-xl font-display">
+            Daily activity
+          </h2>
+          <span className="text-sm text-zinc-400">
+            Requests per day · Peak{" "}
+            {number(maxRequests === 1 && !usage.requests ? 0 : maxRequests)}
+          </span>
+        </div>
+        <div
+          className="mt-8 flex h-40 items-end gap-1 sm:gap-2"
+          role="img"
+          aria-label={`Daily requests from ${usage.days[0].date} to ${usage.days.at(-1).date}. Exact counts are in the daily totals below.`}
+        >
+          {usage.days.map((day) => (
+            <div
+              key={day.date}
+              title={`${day.date}: ${number(day.requests)} requests`}
+              className={`min-w-0 flex-1 rounded-t-sm ${day.requests ? "bg-emerald-400/80" : "bg-zinc-800"}`}
+              style={{
+                height: `${day.requests ? Math.max(3, (day.requests / maxRequests) * 100) : 2}%`,
+              }}
+            />
+          ))}
+        </div>
+        <div className="mt-3 flex justify-between text-xs text-zinc-500">
+          <span>{dateLabel(usage.days[0].date)}</span>
+          <span>{dateLabel(usage.days[14].date)}</span>
+          <span>{dateLabel(usage.days.at(-1).date)}</span>
+        </div>
+        <details className="mt-6 text-sm">
+          <summary className="cursor-pointer text-zinc-400 hover:text-zinc-100">
+            View daily totals
+          </summary>
+          <div className="mt-4 max-h-64 overflow-auto">
+            <table className="w-full text-left">
+              <caption className="sr-only">
+                Daily requests and tokens in UTC
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Date (UTC)</th>
+                  <th scope="col">Requests</th>
+                  <th scope="col">Tokens</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usage.days.map((day) => (
+                  <tr key={day.date} className="border-t border-zinc-800">
+                    <th scope="row" className="py-2 font-normal">
+                      {day.date}
+                    </th>
+                    <td>{number(day.requests)}</td>
+                    <td>{number(day.tokens)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      </section>
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <section className={panel}>
+          <h2 className="text-xl font-display">Model preferences</h2>
+          <p className="mt-2 text-sm text-zinc-400">
+            Ranked by requests, with share of total activity.
+          </p>
+          <div className="mt-6 space-y-6">
+            {usage.models.length ? (
+              usage.models.map((model) => (
+                <div key={model.model}>
+                  <div className="flex flex-wrap justify-between gap-2 text-sm">
+                    <span className="break-all text-zinc-200">
+                      {model.model}
+                    </span>
+                    <span className="text-zinc-400">
+                      {number(model.requests)}{" "}
+                      {model.requests === 1 ? "request" : "requests"} ·{" "}
+                      {usage.requests
+                        ? ((model.requests / usage.requests) * 100).toFixed(1)
+                        : "0.0"}
+                      %
+                    </span>
+                  </div>
+                  <div className="mt-2 h-1.5 rounded-full bg-zinc-800">
+                    <div
+                      className="h-full rounded-full bg-emerald-400/80"
+                      style={{
+                        width: `${usage.requests ? (model.requests / usage.requests) * 100 : 0}%`,
+                      }}
+                    />
+                  </div>
+                  <p className="mt-2 text-xs text-zinc-500">
+                    {number(model.tokens)} tokens
+                  </p>
+                </div>
+              ))
+            ) : (
+              <p className="text-zinc-500">No models used yet.</p>
+            )}
+          </div>
+        </section>
+        <section className={panel}>
+          <h2 className="text-xl font-display">Token breakdown</h2>
+          <dl className="mt-6 space-y-5">
+            {[
+              ["Input", usage.inputTokens],
+              ...(usage.cachedTokens != null
+                ? [["Of which cached", usage.cachedTokens]]
+                : []),
+              ["Output", usage.outputTokens],
+              ["Of which reasoning", usage.reasoningTokens],
+            ].map(([label, value]) => (
+              <div key={label}>
+                <dt className="text-sm text-zinc-400">{label}</dt>
+                <dd className="mt-1 text-2xl text-zinc-200">{number(value)}</dd>
+              </div>
+            ))}
+          </dl>
+          <p className="mt-6 text-xs leading-5 text-zinc-500">
+            {usage.cachedTokens != null &&
+              "Cached tokens are included in input tokens. "}
+            Reasoning is included in output tokens and is not counted twice in
+            the total.
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}
+
+export default function AiUsagePage() {
+  if (!isAiUsageEnabled()) notFound();
+  return (
+    <div className="min-h-screen bg-linear-to-tl from-black via-zinc-900/60 to-black text-zinc-100">
+      <Navigation />
+      <main className="mx-auto max-w-6xl space-y-6 px-5 pb-20 pt-32">
+        <header className="pb-4">
+          <p className="mb-3 text-xs uppercase tracking-widest text-emerald-400">
+            OpenRouter / Activity
+          </p>
+          <h1 className="text-4xl font-display sm:text-5xl">AI usage</h1>
+          <p className="mt-5 max-w-2xl leading-7 text-zinc-400">
+            A look at the models I use and how I use them. Aggregate activity
+            only — no prompts, conversations, or personal details.
+          </p>
+        </header>
+        <Suspense
+          fallback={
+            <p role="status" className={panel}>
+              Loading OpenRouter activity…
+            </p>
+          }
+        >
+          <Usage />
+        </Suspense>
+        <footer className="border-t border-zinc-800 pt-6 text-xs leading-6 text-zinc-500">
+          Source: OpenRouter. Today’s activity is excluded. Only model names and
+          aggregate request and token counts are published; account information,
+          API key details, and spending stay private.
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/app/components/nav.jsx
+++ b/app/components/nav.jsx
@@ -1,3 +1,4 @@
+import { isAiUsageEnabled } from "../ai-usage/data";
 import { GoArrowLeft } from "react-icons/go";
 import Link from "next/link";
 import LoadingIndicator from "./loading-indicator";
@@ -13,7 +14,7 @@ export const Navigation = ({ username }) => {
 		<header>
 			<div className="fixed inset-x-0 top-0 z-50 backdrop-blur duration-200 border-b bg-zinc-900/80 border-zinc-800/60">
 				<div className="container flex flex-row-reverse items-center justify-between p-6 mx-auto">
-					<div className="flex justify-between gap-8 text-base">
+					<div className="flex justify-between gap-4 sm:gap-8 text-base">
 						<Link
 							href={projectsHref}
 							prefetch={false}
@@ -23,6 +24,17 @@ export const Navigation = ({ username }) => {
 								Projects <LoadingIndicator />
 							</span>
 						</Link>
+						{!username && isAiUsageEnabled() && (
+							<Link
+								href="/ai-usage"
+								prefetch={false}
+								className="duration-200 text-zinc-400 hover:text-zinc-100 relative block"
+							>
+								<span className="inline-flex items-center">
+									AI usage <LoadingIndicator />
+								</span>
+							</Link>
+						)}
 						<Link
 							href={contactHref}
 							className="duration-200 text-zinc-400 hover:text-zinc-100 relative block"
@@ -36,7 +48,9 @@ export const Navigation = ({ username }) => {
 					<Link
 						href={homeHref}
 						className="duration-200 text-zinc-300 hover:text-zinc-100"
-						aria-label={username ? `Back to ${username}'s profile` : "Back to home"}
+						aria-label={
+							username ? `Back to ${username}'s profile` : "Back to home"
+						}
 					>
 						<GoArrowLeft className="w-6 h-6" />
 					</Link>

--- a/app/user/_components/landing-page.jsx
+++ b/app/user/_components/landing-page.jsx
@@ -1,3 +1,4 @@
+import { isAiUsageEnabled } from "../../ai-usage/data";
 import Image from "next/image";
 import Link from "next/link";
 import { Suspense } from "react";
@@ -66,15 +67,16 @@ export function LandingPage({ username, isCustomUser = false, user }) {
 	return (
 		<div className="flex flex-col items-center justify-center w-screen min-h-screen overflow-y-auto bg-linear-to-tl from-black via-zinc-600/20 to-black">
 			<nav className="my-16 animate-fade-in">
-				<ul className="flex items-center justify-center gap-4">
-					{navigation.map((item) => (
+				<ul className="flex flex-wrap items-center justify-center gap-4 px-4">
+					{[
+						...navigation,
+						...(!isCustomUser && isAiUsageEnabled()
+							? [{ name: "AI usage", suffix: "/ai-usage" }]
+							: []),
+					].map((item) => (
 						<Link
 							key={item.suffix}
-							href={
-								userPath
-									? `${userPath}${item.suffix}`
-									: item.suffix
-							}
+							href={userPath ? `${userPath}${item.suffix}` : item.suffix}
 							className="text-lg duration-500 text-zinc-500 hover:text-zinc-300"
 						>
 							<span className="inline-flex items-center">
@@ -82,10 +84,7 @@ export function LandingPage({ username, isCustomUser = false, user }) {
 							</span>
 						</Link>
 					))}
-					<ProfileSwitcher
-						username={username}
-						isCustomUser={isCustomUser}
-					/>
+					<ProfileSwitcher username={username} isCustomUser={isCustomUser} />
 				</ul>
 			</nav>
 			<div className="hidden w-screen h-px animate-glow md:block animate-fade-left bg-linear-to-r from-zinc-300/0 via-zinc-300/50 to-zinc-300/0" />
@@ -105,10 +104,7 @@ export function LandingPage({ username, isCustomUser = false, user }) {
 			<div className="my-16 text-center animate-fade-in text-lg text-zinc-500">
 				<div className="w-full min-h-28">
 					<Suspense fallback={<p>Loading profile...</p>}>
-						<UserText
-							promise={userPromise}
-							fallbackName={fallbackName}
-						/>
+						<UserText promise={userPromise} fallbackName={fallbackName} />
 					</Suspense>
 					<Suspense fallback={null}>
 						<ProfileOrganizations username={username} />

--- a/lib/ai-usage.mjs
+++ b/lib/ai-usage.mjs
@@ -1,0 +1,70 @@
+// Missing or partial analytics must not be presented as zero cache usage.
+export function parseCachedTokens(payload) {
+  const result = payload?.data;
+  if (
+    result?.metadata?.truncated !== false ||
+    result?.warnings?.length ||
+    !Array.isArray(result?.data) ||
+    result.data.length !== 1
+  )
+    return null;
+  const raw = result.data[0]?.cached_tokens;
+  if (
+    typeof raw !== "number" &&
+    !(typeof raw === "string" && /^\d+$/.test(raw))
+  )
+    return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+// Only explicitly approved aggregate fields leave this function.
+export function aggregateActivity(rows, now = new Date()) {
+  const days = Array.from({ length: 30 }, (_, i) => {
+    const date = new Date(now);
+    date.setUTCDate(date.getUTCDate() - 30 + i);
+    return { date: date.toISOString().slice(0, 10), requests: 0, tokens: 0 };
+  });
+  const byDay = new Map(days.map((day) => [day.date, day]));
+  const byModel = new Map();
+  let requests = 0,
+    inputTokens = 0,
+    outputTokens = 0,
+    reasoningTokens = 0;
+  const count = (value) =>
+    typeof value === "number" && Number.isFinite(value) && value >= 0
+      ? value
+      : 0;
+  for (const row of rows) {
+    if (!row || typeof row.date !== "string") continue;
+    const day = byDay.get(row.date.slice(0, 10));
+    if (!day) continue;
+    const calls = count(row.requests);
+    const input = count(row.prompt_tokens);
+    const output = count(row.completion_tokens);
+    const model =
+      typeof row.model === "string" && row.model ? row.model : "Unknown model";
+    const entry = byModel.get(model) || { model, requests: 0, tokens: 0 };
+    entry.requests += calls;
+    entry.tokens += input + output;
+    byModel.set(model, entry);
+    day.requests += calls;
+    day.tokens += input + output;
+    requests += calls;
+    inputTokens += input;
+    outputTokens += output;
+    reasoningTokens += Math.min(count(row.reasoning_tokens), output);
+  }
+  return {
+    requests,
+    inputTokens,
+    outputTokens,
+    reasoningTokens,
+    tokens: inputTokens + outputTokens,
+    activeDays: days.filter((day) => day.requests > 0).length,
+    days,
+    models: [...byModel.values()].sort(
+      (a, b) => b.requests - a.requests || a.model.localeCompare(b.model),
+    ),
+  };
+}

--- a/lib/ai-usage.test.mjs
+++ b/lib/ai-usage.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { aggregateActivity, parseCachedTokens } from "./ai-usage.mjs";
+const now = new Date("2026-09-09T12:00:00Z");
+test("combines endpoints by model, fills days, and counts reasoning only once", () => {
+  const rows = [
+    {
+      date: "2026-09-08",
+      model: "a/model",
+      requests: 2,
+      prompt_tokens: 100,
+      completion_tokens: 40,
+      reasoning_tokens: 20,
+      endpoint_id: "private",
+      usage: 42,
+      user_id: "private",
+    },
+    {
+      date: "2026-09-08T00:00:00Z",
+      model: "a/model",
+      requests: 3,
+      prompt_tokens: 50,
+      completion_tokens: 10,
+      reasoning_tokens: 5,
+    },
+    {
+      date: "2026-08-10",
+      model: "b/model",
+      requests: 1,
+      prompt_tokens: 10,
+      completion_tokens: 5,
+    },
+    { date: "2026-09-09", model: "today", requests: 99 },
+    { date: "2026-08-09", model: "expired", requests: 99 },
+  ];
+  const result = aggregateActivity(rows, now);
+  assert.equal(result.requests, 6);
+  assert.equal(result.tokens, 215);
+  assert.equal(result.reasoningTokens, 25);
+  assert.equal(result.activeDays, 2);
+  assert.equal(result.days.length, 30);
+  assert.deepEqual(result.models[0], {
+    model: "a/model",
+    requests: 5,
+    tokens: 200,
+  });
+  assert.equal(result.days.at(-1).requests, 5);
+  assert.equal(JSON.stringify(result).includes("private"), false);
+  assert.equal(JSON.stringify(result).includes("usage"), false);
+});
+test("empty and malformed counts stay finite and nonnegative", () => {
+  const empty = aggregateActivity([], now);
+  assert.equal(empty.requests, 0);
+  assert.deepEqual(empty.models, []);
+  const result = aggregateActivity(
+    [
+      null,
+      { date: "bad" },
+      {
+        date: "2026-09-08",
+        requests: -1,
+        prompt_tokens: Infinity,
+        completion_tokens: 10,
+        reasoning_tokens: 50,
+      },
+    ],
+    now,
+  );
+  assert.equal(result.requests, 0);
+  assert.equal(result.tokens, 10);
+  assert.equal(result.reasoningTokens, 10);
+});
+
+test("cached tokens distinguish zero from missing, invalid, and partial analytics", () => {
+  const payload = (value) => ({
+    data: { data: [{ cached_tokens: value }], metadata: { truncated: false } },
+  });
+  assert.equal(parseCachedTokens(payload("23783")), 23783);
+  assert.equal(parseCachedTokens(payload("0")), 0);
+  for (const value of [null, undefined, "", -1, Infinity, "garbage", 1.5]) {
+    assert.equal(parseCachedTokens(payload(value)), null);
+  }
+  assert.equal(
+    parseCachedTokens({ data: { data: [], metadata: { truncated: false } } }),
+    null,
+  );
+  const partial = payload("10");
+  partial.data.metadata.truncated = true;
+  assert.equal(parseCachedTokens(partial), null);
+});


### PR DESCRIPTION
Adds an optional **AI usage** page at `/ai-usage`. When `OPENROUTER_MANAGEMENT_KEY` is configured, the main portfolio links to daily OpenRouter activity, model preferences, and input/output/reasoning token totals for the last 30 completed UTC days. Without a key, the page returns 404 and its links are hidden; other GitHub profiles do not show the owner's usage links.

Only allowlisted aggregates are published. Prompts, conversations, account/member details, key and endpoint identifiers, and spending are excluded. The key stays server-side. Aggregate results are cached for six hours; the UI shows the update timestamp without a cache-duration label. Cached input tokens are shown when analytics returns a complete valid result, including a real zero; unavailable or partial results omit that row. Cached and reasoning tokens are not double-counted.

README and `.env.example` cover key type, local setup, Vercel environments, caching, failure behavior, and verification. `OPENROUTER_MANAGEMENT_KEY` has been configured separately as a Sensitive variable for Production and Preview in the connected Vercel project; no credential is committed.

Validation:
- `node --test lib/ai-usage.test.mjs` — 3 passing tests covering UTC boundaries, aggregation, privacy filtering, and cached-token parsing.
- `npm run build-only` — passed.
- Chrome — live data, homepage navigation, expandable daily totals, mobile width, and no console errors verified.
- Missing key returns HTTP 404; key absent from HTML and client bundles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional AI usage dashboard showing 30 days of request activity, token totals, model usage, daily trends, and usage details.
  - Added navigation links to the dashboard when enabled for eligible visitors.
  - Added privacy-focused usage summaries and explanatory information.

- **Documentation**
  - Documented setup, configuration, verification, and deployment requirements for the optional AI usage dashboard.

- **Reliability**
  - Improved handling of incomplete or invalid usage data to prevent misleading metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->