### PR TITLE
Add homepage OpenRouter model preference sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,11 @@ Environment changes apply to new deployments. Redeploy the relevant environment 
 ### Verification
 
 Run `node --test lib/ai-usage.test.mjs` for date boundaries, aggregation, privacy filtering, and cached-token parsing (including zero, missing, invalid, and partial results). Run `npm run build-only` to validate the Next.js production build without running the template setup script. With the dev server running, open `/ai-usage` and check the daily totals and token breakdown; without a key, expect a 404.
+
+### Homepage model preference
+
+When the OpenRouter key is configured, the main profile can show a short sentence directly below the Copilot/Codex/Claude contribution summary, linking to AI usage. It uses the same six-hour cached aggregates for the last 30 completed UTC days, without another API request or any prompt data. Custom GitHub profiles never show this sentence.
+
+The sentence requires at least 10 total requests, a leading model with at least 60% of requests, and a lead over the runner-up of at least 20 percentage points. These are conservative display heuristics, not a statistical confidence claim. With fewer than 100 requests to the leading model it says “I dabble with [model] on OpenRouter lately.” At 100 or more it says “I use [model] a lot on OpenRouter lately.” Missing, inconsistent, tied, or inconclusive data produces no sentence. Model versions are retained; unfamiliar model IDs are displayed as supplied rather than guessed.
+
+Run `node --test lib/model-preference.test.mjs` to check these thresholds and naming behavior.

--- a/app/components/model-preference.jsx
+++ b/app/components/model-preference.jsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { getAiUsage, isAiUsageEnabled } from "../ai-usage/data";
+import { getModelPreference } from "../../lib/model-preference.mjs";
+
+export async function ModelPreference() {
+  if (!isAiUsageEnabled()) return null;
+  const sentence = getModelPreference(await getAiUsage());
+  if (!sentence) return null;
+  return (
+    <p className="text-sm max-w-3xl mx-auto px-4 leading-relaxed">
+      <Link
+        href="/ai-usage"
+        prefetch={false}
+        className="underline decoration-zinc-700 underline-offset-4 hover:text-zinc-300"
+        title="Based on requests in the last 30 completed UTC days"
+      >
+        {sentence}
+      </Link>
+    </p>
+  );
+}

--- a/app/user/_components/landing-page.jsx
+++ b/app/user/_components/landing-page.jsx
@@ -1,3 +1,4 @@
+import { ModelPreference } from "../../components/model-preference";
 import { isAiUsageEnabled } from "../../ai-usage/data";
 import Image from "next/image";
 import Link from "next/link";
@@ -115,6 +116,11 @@ export function LandingPage({ username, isCustomUser = false, user }) {
 					<Suspense fallback={null}>
 						<CopilotActivity username={username} />
 					</Suspense>
+					{!isCustomUser && isAiUsageEnabled() && (
+						<Suspense fallback={null}>
+							<ModelPreference />
+						</Suspense>
+					)}
 				</div>
 			</div>
 		</div>

--- a/lib/model-preference.mjs
+++ b/lib/model-preference.mjs
@@ -1,0 +1,51 @@
+// Request-based heuristics for the same 30 completed UTC days as AI usage.
+export function getModelPreference(usage) {
+  if (
+    !usage ||
+    !Number.isSafeInteger(usage.requests) ||
+    usage.requests < 10 ||
+    !Array.isArray(usage.models) ||
+    !usage.models.length
+  )
+    return null;
+  if (
+    usage.models.some(
+      (model) => !Number.isSafeInteger(model.requests) || model.requests < 0,
+    )
+  )
+    return null;
+  const models = [...usage.models].sort((a, b) => b.requests - a.requests);
+  if (
+    models.reduce((total, model) => total + model.requests, 0) !==
+    usage.requests
+  )
+    return null;
+  const [first, second] = models;
+  if (
+    first.requests / usage.requests < 0.6 ||
+    (first.requests - (second?.requests ?? 0)) / usage.requests < 0.2
+  )
+    return null;
+  const name = displayModelName(first.model);
+  if (!name) return null;
+  return first.requests >= 100
+    ? `I use ${name} a lot on OpenRouter lately.`
+    : `I dabble with ${name} on OpenRouter lately.`;
+}
+
+function displayModelName(model) {
+  if (typeof model !== "string") return null;
+  // Keep version and variant information; never guess a model from a partial ID.
+  const match =
+    /^(openai|anthropic)\/([a-z0-9]+(?:[.-][a-z0-9]+)*)(:free)?$/.exec(model);
+  if (!match) return /^[a-z0-9.-]+\/[a-z0-9:._-]+$/i.test(model) ? model : null;
+  const name = match[2]
+    .split("-")
+    .map((part) => {
+      if (part === "gpt") return "GPT";
+      if (/^o\d/.test(part)) return part;
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+  return `${match[1] === "openai" ? "OpenAI " : ""}${name}${match[3] ? " (free)" : ""}`;
+}

--- a/lib/model-preference.test.mjs
+++ b/lib/model-preference.test.mjs
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getModelPreference } from "./model-preference.mjs";
+const usage = (first, second = 0, model = "openai/gpt-5.6-luna") => ({
+  requests: first + second,
+  models: [
+    { model, requests: first },
+    { model: "anthropic/claude-opus-4.8", requests: second },
+  ],
+});
+test("requires enough requests and an unambiguous leader", () => {
+  for (const value of [
+    null,
+    usage(9),
+    usage(5, 5),
+    usage(59, 41),
+    { ...usage(10), requests: 11 },
+  ])
+    assert.equal(getModelPreference(value), null);
+  assert.match(
+    getModelPreference(usage(6, 4)),
+    /^I dabble with OpenAI GPT 5.6 Luna/,
+  );
+  assert.match(getModelPreference(usage(60, 40)), /^I dabble/);
+});
+test("high usage requires 100 requests to the winning model, not overall", () => {
+  assert.match(getModelPreference(usage(99, 50)), /^I dabble/);
+  assert.match(getModelPreference(usage(100, 50)), /^I use .* a lot/);
+});
+test("preserves names, handles unsorted models, and suppresses unknown labels", () => {
+  assert.match(
+    getModelPreference(usage(20, 0, "anthropic/claude-opus-4.8")),
+    /Claude Opus 4.8/,
+  );
+  assert.match(
+    getModelPreference(usage(20, 0, "z-ai/glm-5.3")),
+    /z-ai\/glm-5.3/,
+  );
+  assert.equal(getModelPreference(usage(20, 0, "Unknown model")), null);
+  const value = usage(33, 14);
+  value.models.reverse();
+  assert.match(getModelPreference(value), /Luna/);
+  assert.equal(value.models[0].requests, 14);
+});


### PR DESCRIPTION
Adds a short linked model-preference sentence directly below the homepage's Copilot/Codex/Claude contribution summary. It appears only on the main profile when the OpenRouter key is configured and the existing 30-day usage aggregates identify a clear leading model; custom GitHub profiles and unavailable/inconclusive data show nothing.

Display thresholds:
- At least 10 total requests, at least 60% for the leading model, and a lead of at least 20 percentage points over the runner-up.
- Below 100 requests to the leading model: “I dabble with [model] on OpenRouter lately.”
- At least 100 requests to that model: “I use [model] a lot on OpenRouter lately.”

These are conservative display heuristics. Model versions are retained, unfamiliar model IDs are not guessed, and the sentence links to `/ai-usage`. The component reuses the existing six-hour cached aggregates and streams independently of the other activity summaries. README documents the thresholds and behavior.

Validation: six tests pass across model-preference and usage aggregation; `npm run build-only` passes. Chrome confirms the live Luna sentence directly beneath the coding-agent summary with no console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a homepage message highlighting a user’s leading OpenRouter model based on recent AI usage.
  - Messages appear only when usage data is conclusive and meet defined request and model-share thresholds.
  - The message links to the AI usage page and is unavailable on custom profiles.

- **Documentation**
  - Documented the homepage model preference behavior, display rules, caching, and verification command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->